### PR TITLE
Properly store leaderboard list

### DIFF
--- a/minesweeper.py
+++ b/minesweeper.py
@@ -171,11 +171,10 @@ def leaderboard():
     
     #print(leaderboardlist)
 
-    if len(leaderboardlist) > 20:
-        leaderboardlist.pop(0)
+    visibleleaderboardlist = leaderboardlist[-20:]
 
     i = 31
-    for leaduser in leaderboardlist:
+    for leaduser in visibleleaderboardlist:
         leadusercontent = leaduser.split('|')
         readme[i] = "| " + leadusercontent[0] + " | <a href='" + leadusercontent[2] + "'>" + leadusercontent[1] + "</a>|"
         i += 1


### PR DESCRIPTION
Leaderboard now stores users outside of the top 20 as well. Only the top 20 will be displayed, but other users will still be stored in the backing file, giving them a chance to enter the leaderboard.